### PR TITLE
Fix InfoTooltip whitespace wrapping

### DIFF
--- a/src/components/DrinkList/DrinkList.jsx
+++ b/src/components/DrinkList/DrinkList.jsx
@@ -16,7 +16,7 @@ import {
   InfoContainer,
   InfoText,
   IconContainer,
-} from '../../shared-components/InfoTooltip/infoTolltip';
+} from '../../shared-components/InfoTooltip/infoTooltip';
 import useUserRole from '../../hooks/useUserRole';
 import { useNotification } from '../../context/NotificationContext';
 import IconAdd from '../../shared-components/Icons/IconAdd';

--- a/src/shared-components/InfoTooltip/infoTooltip.js
+++ b/src/shared-components/InfoTooltip/infoTooltip.js
@@ -12,7 +12,7 @@ export const InfoText = styled.p`
   position: absolute;
   top: 100%;
   left: 0;
-  white-space: wrap;
+  white-space: normal;
   background-color: ${({ theme }) => theme.grey[800]};
   color: ${({ theme }) => theme.grey[100]};
   padding: 8px 12px;


### PR DESCRIPTION
## Summary
- rename `infoTolltip.js` to `infoTooltip.js`
- correct invalid `white-space: wrap` style
- update import in `DrinkList`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fff4d95908320b4e98667393d6547