### PR TITLE
Fix theme mode not passed

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -185,7 +185,7 @@ export const useMode = () => {
     []
   );
 
-  const theme = useMemo(() => tokens(mode), [mode]);
+  const theme = useMemo(() => ({ ...tokens(mode), mode }), [mode]);
 
   return [theme, colorMode];
 };


### PR DESCRIPTION
## Summary
- expose current theme mode inside `useMode`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fee16bfa48320b1e5849181e897c5